### PR TITLE
Add TSWApi library and test project scaffolding

### DIFF
--- a/TSWApi.Tests/ApiClientTests.fs
+++ b/TSWApi.Tests/ApiClientTests.fs
@@ -1,0 +1,7 @@
+module TSWApi.Tests.ApiClientTests
+
+open Xunit
+
+[<Fact>]
+let ``Placeholder test - api client`` () =
+    Assert.True(true)

--- a/TSWApi.Tests/HttpTests.fs
+++ b/TSWApi.Tests/HttpTests.fs
@@ -1,0 +1,7 @@
+module TSWApi.Tests.HttpTests
+
+open Xunit
+
+[<Fact>]
+let ``Placeholder test - http`` () =
+    Assert.True(true)

--- a/TSWApi.Tests/TSWApi.Tests.fsproj
+++ b/TSWApi.Tests/TSWApi.Tests.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TypesTests.fs" />
+    <Compile Include="HttpTests.fs" />
+    <Compile Include="ApiClientTests.fs" />
+    <Compile Include="TreeNavigationTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TSWApi\TSWApi.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/TSWApi.Tests/TreeNavigationTests.fs
+++ b/TSWApi.Tests/TreeNavigationTests.fs
@@ -1,0 +1,7 @@
+module TSWApi.Tests.TreeNavigationTests
+
+open Xunit
+
+[<Fact>]
+let ``Placeholder test - tree navigation`` () =
+    Assert.True(true)

--- a/TSWApi.Tests/TypesTests.fs
+++ b/TSWApi.Tests/TypesTests.fs
@@ -1,0 +1,7 @@
+module TSWApi.Tests.TypesTests
+
+open Xunit
+
+[<Fact>]
+let ``Placeholder test - types`` () =
+    Assert.True(true)

--- a/TSWApi/ApiClient.fs
+++ b/TSWApi/ApiClient.fs
@@ -1,0 +1,6 @@
+namespace TSWApi
+
+/// Core API client operations for TSW6 GET endpoints.
+module ApiClient =
+    // API client will be implemented TDD-style
+    ()

--- a/TSWApi/Http.fs
+++ b/TSWApi/Http.fs
@@ -1,0 +1,6 @@
+namespace TSWApi
+
+/// HTTP client infrastructure for the TSW6 API.
+module Http =
+    // HTTP client will be implemented TDD-style
+    ()

--- a/TSWApi/TSWApi.fsproj
+++ b/TSWApi/TSWApi.fsproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="Http.fs" />
+    <Compile Include="ApiClient.fs" />
+    <Compile Include="TreeNavigation.fs" />
+  </ItemGroup>
+
+</Project>

--- a/TSWApi/TreeNavigation.fs
+++ b/TSWApi/TreeNavigation.fs
@@ -1,0 +1,6 @@
+namespace TSWApi
+
+/// Tree navigation helpers for the TSW6 node hierarchy.
+module TreeNavigation =
+    // Tree navigation will be implemented TDD-style
+    ()

--- a/TSWApi/Types.fs
+++ b/TSWApi/Types.fs
@@ -1,0 +1,6 @@
+namespace TSWApi
+
+/// Core types for the Train Sim World 6 API.
+module Types =
+    // Types will be implemented TDD-style
+    ()

--- a/TrainSimWorldAddons.slnx
+++ b/TrainSimWorldAddons.slnx
@@ -1,3 +1,5 @@
 <Solution>
   <Project Path="AWSSunflower/AWSSunflower.fsproj" />
+  <Project Path="TSWApi.Tests/TSWApi.Tests.fsproj" />
+  <Project Path="TSWApi/TSWApi.fsproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- TSWApi.fsproj: F# class library (.NET 10) with stub modules (Types, Http, ApiClient, TreeNavigation)
- TSWApi.Tests.fsproj: xUnit test project with placeholder tests for each module
- Updated solution to include both projects
- GenerateDocumentationFile enabled for fsdocs integration
- All 4 placeholder tests pass locally