### PR TITLE
Implement tree navigation with TDD tests

### DIFF
--- a/TSWApi.Tests/TreeNavigationTests.fs
+++ b/TSWApi.Tests/TreeNavigationTests.fs
@@ -1,7 +1,137 @@
 module TSWApi.Tests.TreeNavigationTests
 
 open Xunit
+open TSWApi.Types
+open TSWApi.TreeNavigation
+
+// ── parseNodePath ──
 
 [<Fact>]
-let ``Placeholder test - tree navigation`` () =
-    Assert.True(true)
+let ``parseNodePath splits slash-separated path`` () =
+    let result = parseNodePath "Root/Player/TransformComponent0"
+    Assert.Equal<string list>([ "Root"; "Player"; "TransformComponent0" ], result)
+
+[<Fact>]
+let ``parseNodePath returns single element for leaf`` () =
+    let result = parseNodePath "VirtualRailDriver"
+    Assert.Equal<string list>([ "VirtualRailDriver" ], result)
+
+[<Fact>]
+let ``parseNodePath returns empty list for empty string`` () =
+    let result = parseNodePath ""
+    Assert.Empty(result)
+
+// ── buildNodePath ──
+
+[<Fact>]
+let ``buildNodePath joins segments with slash`` () =
+    let result = buildNodePath [ "Root"; "Player"; "TransformComponent0" ]
+    Assert.Equal("Root/Player/TransformComponent0", result)
+
+[<Fact>]
+let ``buildNodePath returns empty for empty list`` () =
+    let result = buildNodePath []
+    Assert.Equal("", result)
+
+// ── getNodeAtPath ──
+
+let sampleTree: Node list =
+    [ { NodePath = "Root/VirtualRailDriver"
+        NodeName = "VirtualRailDriver"
+        Nodes = None
+        Endpoints = None }
+      { NodePath = "Root/Player"
+        NodeName = "Player"
+        Nodes =
+            Some
+                [ { NodePath = "Root/Player/TransformComponent0"
+                    NodeName = "TransformComponent0"
+                    Nodes = None
+                    Endpoints = None }
+                  { NodePath = "Root/Player/PC_InputComponent0"
+                    NodeName = "PC_InputComponent0"
+                    Nodes = None
+                    Endpoints = None } ]
+        Endpoints = None }
+      { NodePath = "Root/CurrentDrivableActor"
+        NodeName = "CurrentDrivableActor"
+        Nodes =
+            Some
+                [ { NodePath = "Root/CurrentDrivableActor/AWS_TPWS_Service"
+                    NodeName = "AWS_TPWS_Service"
+                    Nodes = Some []
+                    Endpoints =
+                        Some
+                            [ { Name = "Property.AWS_SunflowerState"
+                                Writable = false } ] } ]
+        Endpoints = None } ]
+
+[<Fact>]
+let ``getNodeAtPath finds top-level node`` () =
+    let result = getNodeAtPath sampleTree [ "VirtualRailDriver" ]
+    Assert.True(result.IsSome)
+    Assert.Equal("VirtualRailDriver", result.Value.NodeName)
+
+[<Fact>]
+let ``getNodeAtPath finds nested node`` () =
+    let result = getNodeAtPath sampleTree [ "Player"; "TransformComponent0" ]
+    Assert.True(result.IsSome)
+    Assert.Equal("TransformComponent0", result.Value.NodeName)
+
+[<Fact>]
+let ``getNodeAtPath finds deeply nested node`` () =
+    let result = getNodeAtPath sampleTree [ "CurrentDrivableActor"; "AWS_TPWS_Service" ]
+    Assert.True(result.IsSome)
+    Assert.Equal("AWS_TPWS_Service", result.Value.NodeName)
+
+[<Fact>]
+let ``getNodeAtPath returns None for non-existent path`` () =
+    let result = getNodeAtPath sampleTree [ "NonExistent" ]
+    Assert.True(result.IsNone)
+
+[<Fact>]
+let ``getNodeAtPath returns None for non-existent nested path`` () =
+    let result = getNodeAtPath sampleTree [ "Player"; "NonExistent" ]
+    Assert.True(result.IsNone)
+
+[<Fact>]
+let ``getNodeAtPath returns None for empty path`` () =
+    let result = getNodeAtPath sampleTree []
+    Assert.True(result.IsNone)
+
+// ── findEndpoint ──
+
+[<Fact>]
+let ``findEndpoint finds endpoint on node`` () =
+    let node = getNodeAtPath sampleTree [ "CurrentDrivableActor"; "AWS_TPWS_Service" ]
+    let endpoint = findEndpoint node.Value "Property.AWS_SunflowerState"
+    Assert.True(endpoint.IsSome)
+    Assert.Equal("Property.AWS_SunflowerState", endpoint.Value.Name)
+    Assert.False(endpoint.Value.Writable)
+
+[<Fact>]
+let ``findEndpoint returns None for non-existent endpoint`` () =
+    let node = getNodeAtPath sampleTree [ "CurrentDrivableActor"; "AWS_TPWS_Service" ]
+    let endpoint = findEndpoint node.Value "Property.NonExistent"
+    Assert.True(endpoint.IsNone)
+
+[<Fact>]
+let ``findEndpoint returns None when node has no endpoints`` () =
+    let node = getNodeAtPath sampleTree [ "VirtualRailDriver" ]
+    let endpoint = findEndpoint node.Value "Property.Something"
+    Assert.True(endpoint.IsNone)
+
+// ── getChildNodes ──
+
+[<Fact>]
+let ``getChildNodes returns children of node`` () =
+    let node = getNodeAtPath sampleTree [ "Player" ]
+    let children = getChildNodes node.Value
+    Assert.Equal(2, children.Length)
+    Assert.Equal("TransformComponent0", children.[0].NodeName)
+
+[<Fact>]
+let ``getChildNodes returns empty for leaf node`` () =
+    let node = getNodeAtPath sampleTree [ "VirtualRailDriver" ]
+    let children = getChildNodes node.Value
+    Assert.Empty(children)

--- a/TSWApi/TreeNavigation.fs
+++ b/TSWApi/TreeNavigation.fs
@@ -1,6 +1,40 @@
 namespace TSWApi
 
+open TSWApi.Types
+
 /// Tree navigation helpers for the TSW6 node hierarchy.
 module TreeNavigation =
-    // Tree navigation will be implemented TDD-style
-    ()
+
+    /// Split a slash-separated node path into segments.
+    let parseNodePath (path: string) : string list =
+        if System.String.IsNullOrEmpty(path) then []
+        else path.Split('/') |> Array.toList
+
+    /// Join path segments with slashes.
+    let buildNodePath (segments: string list) : string =
+        System.String.Join("/", segments)
+
+    /// Navigate a node tree to find a node at the given path segments.
+    let rec getNodeAtPath (nodes: Node list) (path: string list) : Node option =
+        match path with
+        | [] -> None
+        | [ name ] -> nodes |> List.tryFind (fun n -> n.NodeName = name)
+        | name :: rest ->
+            nodes
+            |> List.tryFind (fun n -> n.NodeName = name)
+            |> Option.bind (fun n ->
+                match n.Nodes with
+                | Some children -> getNodeAtPath children rest
+                | None -> None)
+
+    /// Find an endpoint by name on a node.
+    let findEndpoint (node: Node) (endpointName: string) : Endpoint option =
+        match node.Endpoints with
+        | Some endpoints -> endpoints |> List.tryFind (fun e -> e.Name = endpointName)
+        | None -> None
+
+    /// Get the child nodes of a node (empty list if leaf).
+    let getChildNodes (node: Node) : Node list =
+        match node.Nodes with
+        | Some children -> children
+        | None -> []


### PR DESCRIPTION
## Summary
Tree navigation helpers for the TSW6 node hierarchy with 16 tests.

### Functions
- \parseNodePath\: split slash-separated paths
- \uildNodePath\: join path segments
- \getNodeAtPath\: recursive tree traversal
- \indEndpoint\: locate endpoint by name on a node
- \getChildNodes\: get child nodes (empty for leaves)

### Tests (16 passing, 53 total)
- Path parsing/building edge cases
- Tree traversal: top-level, nested, deep, non-existent
- Endpoint finding + child node access

Closes #8, Closes #9